### PR TITLE
fixing up logic for return value

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,9 +63,7 @@ runs:
         fi
         cmd="${cmd} ${path} ${args}"
         printf "${cmd}\n"
-        $cmd
-        retval=$?
-        echo "Return value is ${retval}"
+        $cmd && retval=0 || retval=1
         echo "retval=${retval}" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
if the command fails, we should catch and manually set the envar this is so the composite action does not exit

This will close #17 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>