### PR TITLE
tiny fix for version bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/rse-ops/actions-updater/tree/main) (0.0.x)
+ - bug fix to version updater (0.0.12)
  - adding tests for updaters, docs, container (0.0.11)
  - adding set-output and set-state updaters (0.0.1)
  - Project skeleton release (0.0.0)

--- a/action_updater/main/updaters/version/update.py
+++ b/action_updater/main/updaters/version/update.py
@@ -65,6 +65,11 @@ class VersionUpdater(UpdaterBase):
                 if not updated:
                     updated = self.get_tagged_commit(tags)
 
+                    # If not updated here, first try to get major tags
+                    if not updated:
+                        updated = self.get_major_tag(tags)
+
+                # If we don't have tags by this point, no go - we cannot parse
                 if not updated:
                     continue
                 updated = f"{repo}@{updated}"

--- a/action_updater/version.py
+++ b/action_updater/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "action-updater"


### PR DESCRIPTION
we were not getting updates for a workflow with all major releases for versions. The reason is because our tags updater expects at least a minor release. This falls back to the major tag parser if this happens.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>