### PR TITLE
Add Installation Instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ You can see the [⭐️ Documentation ⭐️](https://vsoch.github.io/action-upd
 
 ## ⭐️ Quick Start ⭐️
 
+### Installation 
+
+Install with pip:
+
+```bash
+$ pip install action-lint
+```
+
 ### Usage
 
 For all commands below, the actions updater can accept a directory with yaml files,

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ You can see the [⭐️ Documentation ⭐️](https://vsoch.github.io/action-upd
 
 ### Installation 
 
-Install with pip:
+The module is available in pypi as [action-updater](https://pypi.org/project/action-updater/),
+and to install we first recommend some kind of virtual environment:
 
 ```bash
-$ pip install action-lint
+$ python -m venv env
+$ source env/bin/activate
+```
+
+And then install from pypi using pip:
+
+```bash
+$ pip install action-updater
 ```
 
 ### Usage

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -12,7 +12,7 @@ The Action Updater can be installed from pypi, or from source.
 Pypi
 ====
 
-The module is available in pypi as `action-updater <https://pypi.org/project/singularity-hpc/>`_,
+The module is available in pypi as `action-updater <https://pypi.org/project/action-updater/>`_,
 and to install we first recommend some kind of virtual environment:
 
 .. code-block:: console


### PR DESCRIPTION
I would be happy to add more, not sure if we want to mention using a virtual environment, or using `pipx` to install it. Personally for tools like this, I like to use `pipx` so I can use it system wide and not worry about which conda env or python virtual env I have activated. 